### PR TITLE
macOS — Remove i386 and add Apple Silicon support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean32:
 	mkdir lib64 && cd lib64 && CFLAGS='-m64' cmake ../src && make && make test
 
 universal: clean
-	mkdir build && cd build && cmake ../src -DCMAKE_OSX_ARCHITECTURES="x86_64;i386" && make && make test
+	mkdir build && cd build && cmake ../src -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64e" && make && make test
 
 clean64:
 	rm -rf lib64
@@ -30,12 +30,12 @@ clean: clean32 clean64
 dist_prepare: test
 	mkdir -p usr/share/doc/stderred && cp README.md usr/share/doc/stderred/
 
-package_deb: dist_prepare 
+package_deb: dist_prepare
 	rm -f *.deb
 	mkdir -p usr/lib && cp build/libstderred.so usr/lib/
 	fpm -s dir -t deb -n stderred -v `git tag | grep v | cut -d 'v' -f 2 | sort -nr | head -n 1` --license MIT --vendor 'Marcin Kulik' -m 'Marcin Kulik <marcin.kulik+stderred@gmail.com>' --description "stderr in red" --url https://github.com/sickill/stderred usr/bin/stderred usr/lib/libstderred.so usr/share/stderred/stderred.sh usr/share/doc/stderred/README.md
 
-package_rpm_64: dist_prepare 
+package_rpm_64: dist_prepare
 	rm -f *.rpm
 	mkdir -p usr/lib64 && cp build/libstderred.so usr/lib64/
 	fpm -s dir -t rpm -n stderred -v `git tag | grep v | cut -d 'v' -f 2 | sort -nr | head -n 1` --license MIT --vendor 'Marcin Kulik' -m 'Marcin Kulik <marcin.kulik+stderred@gmail.com>' --description "stderr in red" --url https://github.com/sickill/stderred usr/bin/stderred usr/lib64/libstderred.so usr/share/stderred/stderred.sh usr/share/doc/stderred/README.md


### PR DESCRIPTION
i386 (32 bits) has been deprecated for a long time on macOS, not supported by libSystem,  and it thus breaks compilation with the following error:

```
ld: warning: The i386 architecture is deprecated for macOS (remove from the Xcode build setting: ARCHS)
ld: warning: ignoring file /Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk/usr/lib/libSystem.tbd, missing required architecture i386 in file /Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk/usr/lib/libSystem.tbd (3 slices)
ld: dynamic executables or dylibs must link with libSystem.dylib for architecture i386
cc: error: linker command failed with exit code 1 (use -v to see invocation)
```

Fix https://github.com/ku1ik/stderred/issues/91
